### PR TITLE
Use next/previous in swipeEnd to change slide the index

### DIFF
--- a/src/dub-step.js
+++ b/src/dub-step.js
@@ -562,22 +562,11 @@ class DubStep extends Component {
     if (touchObject.swipeLength > minSwipe) {
       e.preventDefault();
 
-      let newIndex;
-
-      switch (swipeDirectionSign) {
-        case -1:
-          newIndex = this.getNextIndex();
-          break;
-        case 1:
-          newIndex = this.props.swipeIterateOnly
-            ? this.getNextIndex()
-            : this.getPreviousIndex();
-          break;
-        default:
-          newIndex = this.getControlledProp('index');
+      if (this.props.swipeIterateOnly || swipeDirectionSign === -1) {
+        this.next();
+      } else {
+        this.previous();
       }
-
-      this.changeSlide(newIndex);
     }
   };
   changeSlide = index => {


### PR DESCRIPTION
Closes #4 

**What**:
Use `this.next()` and `this.previous()` in `swipeEnd` so that `onNext` & `onPrevious` prop callbacks get called.

**Why**:
The same prop functions should be called when swipe as are when clicking a button that has `getNextControl/getPreviousControl` props spread into them.
**How**:
Remove `changeSlide` call and next/previous.

**Checklist**:
- [X] Documentation -NA
- [X] Tests - Test manually with example repo. Still no time to write more test 😞 
- [X] Ready to be merged

Thanks @connor-baer for the suggestion!
