### PR TITLE
[Bugfix] Get swiped element's size consistently.

### DIFF
--- a/src/dub-step.js
+++ b/src/dub-step.js
@@ -541,7 +541,8 @@ class DubStep extends Component {
     }
     const posX = e.touches !== undefined ? e.touches[0].pageX : e.clientX;
     const posY = e.touches !== undefined ? e.touches[0].pageY : e.clientY;
-    this.targetSize = e.target[this.props.vertical ? 'height' : 'width'];
+    this.targetSize =
+      e.target[this.props.vertical ? 'offsetHeight' : 'offsetWidth'];
     this.setState(
       {
         dragging: true,


### PR DESCRIPTION
Fixes swiping on certain elements.

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->
**What**: In rare cases when swiping on mobile `event.target[width/height]` is undefined ([here](https://github.com/infiniteluke/dub-step/blob/master/src/dub-step.js#L544)). This prevents `this.previous()`/`this.next()` from being called ([here](https://github.com/infiniteluke/dub-step/blob/master/src/dub-step.js#L662)). You can see the issue in action [here (the testimonial carousel)](https://sumup.com/connors-testing-page/). 

<!-- Why are these changes necessary? -->
**Why**: Dubstep should respond to swipes no matter which part of the slide is being swiped on.

<!-- How were these changes implemented? -->
**How**: Switch to using `event.target[offsetWidth/offsetHeight]`.  

<!-- Have you done all of these things?  -->
**Checklist**:
<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->
- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to AUTHORS file <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
